### PR TITLE
#45 -- Made paper shelf and summary popup responsive on mobile devices

### DIFF
--- a/src/components/ArtGallery/index.js
+++ b/src/components/ArtGallery/index.js
@@ -42,15 +42,17 @@ const ArtGallery = () => {
               <div className="content">
                 <p className="title">{port.name}</p>
                 <h4 className="description">{port.description}</h4>
-                <button
-                  className="btn"
-                  onClick={() => {
-                    setShowKey(idx);
-                    setShowPopup(true);
-                  }}
-                >
-                  View
-                </button>
+                <div className="button-container">
+                  <button
+                    className="btn"
+                    onClick={() => {
+                      setShowKey(idx);
+                      setShowPopup(true);
+                    }}
+                  >
+                    View
+                  </button>
+                </div>
               </div>
             </div>
           );

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -114,6 +114,17 @@
       background: #ffd700;
     }
 
+    .button-container {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      justify-content: space-evenly;
+
+      a {
+        text-decoration: none;
+      }
+    }
+
     &:after {
       content: "";
       background: linear-gradient(180deg, #ffd700, #000);

--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -108,6 +108,7 @@
 
     &.skills-page,
     &.career-page,
+    &.paper-shelf-page,
     &.art-gallery-page {
       width: 100%;
       padding: 20px;
@@ -121,6 +122,55 @@
       .image-box {
         height: 200px;
         max-width: calc(50% - 10px);
+
+        .content {
+          width: calc(100% - 1rem);
+          padding: 1rem 0.5rem;
+        }
+
+        .btn, .btn-disabled {
+          margin-top: 10px;
+          margin-bottom: 10px;
+          margin-left: 2px;
+          margin-right: 2px;
+          padding: 0 8px;
+          line-height: 28px;
+          height: 35px;
+          font-size: 14px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .container {
+    &.skills-page,
+    &.career-page,
+    &.paper-shelf-page,
+    &.art-gallery-page {
+      .image-box {
+        .content {
+          width: calc(100% - 1rem);
+          padding: 1rem 0.5rem;
+        }
+
+        .btn, .btn-disabled {
+          margin-top: 10px;
+          margin-bottom: 10px;
+          margin-left: 2px;
+          margin-right: 2px;
+          padding: 0 8px;
+          line-height: 24px;
+          height: 30px;
+          font-size: 12px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
       }
     }
   }

--- a/src/components/PaperShelf/index.js
+++ b/src/components/PaperShelf/index.js
@@ -146,19 +146,21 @@ const PaperShelf = () => {
                     value={(port.pagesRead / port.totalPages) * 100}
                   />
                 </Box>
-                <button className="btn" onClick={() => {}}>
-                  <span className={"btn-name"}>View</span>
-                  <FontAwesomeIcon icon={faArrowUpRightFromSquare} color="#ffffff" />
-                </button>
-                <button
-                  className={port.summary ? "btn": "btn-disabled"}
-                  onClick={() => {
-                    const summaryId = "books" + "-" + showBookKey + "-" + idx
-                    openSummaryPopup(summaryId, port.summary);
-                  }}
-                >
-                  Summary
-                </button>
+                <div className="button-container">
+                  <button className="btn" onClick={() => {}}>
+                    <span className={"btn-name"}>View</span>
+                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} color="#ffffff" />
+                  </button>
+                  <button
+                    className={port.summary ? "btn": "btn-disabled"}
+                    onClick={() => {
+                      const summaryId = "books" + "-" + showBookKey + "-" + idx
+                      openSummaryPopup(summaryId, port.summary);
+                    }}
+                  >
+                    Summary
+                  </button>
+                </div>
               </div>
             </div>
           );
@@ -185,21 +187,23 @@ const PaperShelf = () => {
                 <p className="title">{port.name}</p>
                 <h4 className="description">{port.description}</h4>
                 <h4 className="authors">Authors: {port.authors}</h4>
-                <a target={"_blank"} rel={"noreferrer"} href={port.link}>
-                  <button className="btn" onClick={() => {}}>
-                    <span className={"btn-name"}>View</span>
-                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} color="#ffffff" />
+                <div className="button-container">
+                  <a target={"_blank"} rel={"noreferrer"} href={port.link}>
+                    <button className="btn" onClick={() => {}}>
+                      <span className={"btn-name"}>View</span>
+                      <FontAwesomeIcon icon={faArrowUpRightFromSquare} color="#ffffff" />
+                    </button>
+                  </a>
+                  <button
+                    className={port.summary ? "btn": "btn-disabled"}
+                    onClick={() => {
+                      const summaryId = "papers" + "-" + showBookKey + "-" + idx;
+                      openSummaryPopup(summaryId, port.summary);
+                    }}
+                  >
+                    Summary
                   </button>
-                </a>
-                <button
-                  className={port.summary ? "btn": "btn-disabled"}
-                  onClick={() => {
-                    const summaryId = "papers" + "-" + showBookKey + "-" + idx;
-                    openSummaryPopup(summaryId, port.summary);
-                  }}
-                >
-                  Summary
-                </button>
+                </div>
               </div>
             </div>
           );
@@ -222,21 +226,23 @@ const PaperShelf = () => {
                 <p className="title">{port.name}</p>
                 <h4 className="description">{port.description}</h4>
                 <h4 className="authors">Authors: {port.authors}</h4>
-                <a target={"_blank"} rel={"noreferrer"} href={port.link}>
-                  <button className="btn" onClick={() => {}}>
-                    <span className={"btn-name"}>View</span>
-                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} color="#ffffff" />
+                <div className="button-container">
+                  <a target={"_blank"} rel={"noreferrer"} href={port.link}>
+                    <button className="btn" onClick={() => {}}>
+                      <span className={"btn-name"}>View</span>
+                      <FontAwesomeIcon icon={faArrowUpRightFromSquare} color="#ffffff" />
+                    </button>
+                  </a>
+                  <button
+                    className={port.summary ? "btn": "btn-disabled"}
+                    onClick={() => {
+                      const summaryId = "blogs" + "-" + showBookKey + "-" + idx;
+                      openSummaryPopup(summaryId, port.summary);
+                    }}
+                  >
+                    Summary
                   </button>
-                </a>
-                <button
-                  className={port.summary ? "btn": "btn-disabled"}
-                  onClick={() => {
-                    const summaryId = "blogs" + "-" + showBookKey + "-" + idx;
-                    openSummaryPopup(summaryId, port.summary);
-                  }}
-                >
-                  Summary
-                </button>
+                </div>
               </div>
             </div>
           );

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -342,18 +342,6 @@
       text-overflow: ellipsis;
       white-space: unset;
     }
-
-    .description {
-      display: none;
-    }
-
-    .authors {
-      display: none;
-    }
-
-    .content {
-      bottom: 0;
-    }
   }
 
   .summary-title {

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -56,7 +56,7 @@
 
 .images-container {
   display: flex;
-  gap: 15px;
+  gap: 20px;
   flex-wrap: wrap;
   padding: 20px 0;
 }
@@ -146,6 +146,9 @@
     font-weight: 700;
     transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
   }
 
   .btn-disabled {
@@ -162,6 +165,17 @@
 
   .btn-name {
     padding-right: 5px;
+  }
+
+  .button-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-evenly;
+
+    a {
+      text-decoration: none;
+    }
   }
 
   &:after {
@@ -296,13 +310,64 @@
 }
 
 @media screen and (max-width: 1200px) {
-  .image-box {
-    flex: 1 1 30% !important;
+  .paper-shelf-page {
+    .title {
+      font-size: 16px;
+      line-height: 18px;
+      overflow: visible;
+      text-overflow: ellipsis;
+      white-space: unset;
+    }
+
+    .description {
+      display: none;
+    }
+
+    .authors {
+      display: none;
+    }
+
+    .content {
+      bottom: 0;
+    }
   }
 }
 
 @media screen and (max-width: 800px) {
-  .image-box {
-    flex: 1 1 40% !important;
+  .paper-shelf-page {
+    .title {
+      font-size: 14px;
+      line-height: 16px;
+      overflow: visible;
+      text-overflow: ellipsis;
+      white-space: unset;
+    }
+
+    .description {
+      display: none;
+    }
+
+    .authors {
+      display: none;
+    }
+
+    .content {
+      bottom: 0;
+    }
+  }
+
+  .summary-title {
+    font-size: 2rem;
+    margin-top: 2rem;
+  }
+
+  .summary-popup {
+    width: calc(100% - 50px);
+    padding: 10px;
+  }
+
+  .summary-section {
+    padding: 0 1rem;
+    font-size: 1rem;
   }
 }

--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -39,15 +39,17 @@ const Skills = () => {
               <div className="content">
                 <p className="title">{port.name}</p>
                 <h4 className="description">{port.description}</h4>
-                <button
-                  className="btn"
-                  onClick={() => {
-                    setShowKey(idx);
-                    setShowPopup(true);
-                  }}
-                >
-                  View
-                </button>
+                <div className="button-container">
+                  <button
+                    className="btn"
+                    onClick={() => {
+                      setShowKey(idx);
+                      setShowPopup(true);
+                    }}
+                  >
+                    View
+                  </button>
+                </div>
               </div>
             </div>
           );

--- a/src/components/Skills/index.scss
+++ b/src/components/Skills/index.scss
@@ -97,6 +97,17 @@
       background: #ffd700;
     }
 
+    .button-container {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      justify-content: space-evenly;
+
+      a {
+        text-decoration: none;
+      }
+    }
+
     &:after {
       content: "";
       background: linear-gradient(180deg, #ffd700, #000);


### PR DESCRIPTION
# Made paper shelf and summary popup responsive on mobile devices

## Changes
- Made paper shelf and summary popup responsive on mobile devices
- Removed description and authors for the devices below 1200px resolution in the paper shelf
- Made view and summary buttons responsive for paper shelf, art gallery and skills section