### PR TITLE
fix(paper-shelf): fix title clipping and button overflow on mobile

### DIFF
--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -122,8 +122,8 @@
         .btn, .btn-disabled {
           margin-top: 10px;
           margin-bottom: 10px;
-          margin-left: 2px;
-          margin-right: 2px;
+          margin-left: 6px;
+          margin-right: 6px;
           padding: 0 8px;
           line-height: 28px;
           height: 35px;
@@ -158,8 +158,8 @@
         }
 
         .btn, .btn-disabled {
-          margin-top: 10px;
-          margin-bottom: 10px;
+          margin-top: 4px;
+          margin-bottom: 4px;
           margin-left: 2px;
           margin-right: 2px;
           padding: 0 8px;

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -333,13 +333,13 @@
 }
 
 @media screen and (max-width: 1200px) {
-  .paper-shelf-page {
+  .paper-shelf-page .image-box {
     .title {
       font-size: 16px;
       line-height: 18px;
-      overflow: visible;
+      overflow: hidden;
       text-overflow: ellipsis;
-      white-space: unset;
+      white-space: nowrap;
     }
 
     .description {
@@ -353,17 +353,23 @@
     .content {
       bottom: 0;
     }
+
   }
 }
 
 @media screen and (max-width: 800px) {
-  .paper-shelf-page {
+  .paper-shelf-page .image-box {
     .title {
       font-size: 14px;
       line-height: 16px;
-      overflow: visible;
+      overflow: hidden;
       text-overflow: ellipsis;
-      white-space: unset;
+      white-space: nowrap;
+    }
+
+    .button-container {
+      flex-wrap: wrap;
+      justify-content: center;
     }
   }
 


### PR DESCRIPTION
- Fix CSS specificity bug where media query .title overrides were
  ignored (2-class selector lost to 3-class base); title stayed at
  24px on mobile, overflowing the 200px card height and clipping
  the first line
- Clamp title to single line with ellipsis on mobile (≤1200px/≤800px)
- Wrap and center View/Summary buttons only on mobile (≤800px);
  wider screens keep side-by-side layout with space-evenly
- Restore 1200px button margins (10px vertical, 6px horizontal);
  reduce vertical margin to 4px only at ≤800px for stacked buttons

Issue: #95 