### PR TITLE
style(paper-shelf): modernize summary popup UI and fix card hover artifacts

### DIFF
--- a/src/components/PaperShelf/index.js
+++ b/src/components/PaperShelf/index.js
@@ -302,19 +302,14 @@ const PaperShelf = () => {
   return (
     <>
       <div className={showPopup ? "summary-popup" : "popup-disabled"} ref={popupRef}>
-        <div>
-          <FontAwesomeIcon
-            onClick={closeSummaryPopup}
-            icon={faClose}
-            color={"#e46976"}
-            size={"3x"}
-            className={showPopup ? "close-summary-popup-icon" : ""}
-          />
-          <h1 className={"summary-title"}>{showSummary?.title}</h1>
-          <hr/>
-          <div className={"summary-section"}>
-            <p>{parse(showSummary.summary ? showSummary.summary : "")}</p>
-          </div>
+        <FontAwesomeIcon
+          onClick={closeSummaryPopup}
+          icon={faClose}
+          className={"close-summary-popup-icon"}
+        />
+        <h1 className={"summary-title"}>{showSummary?.title}</h1>
+        <div className={"summary-section"}>
+          {parse(showSummary.summary ? showSummary.summary : "")}
         </div>
       </div>
       <div className={"container paper-shelf-page"}>

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -92,7 +92,8 @@
     width: calc(100% - 40px);
     z-index: 3;
     padding: 10px 20px;
-    transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+    transition: bottom 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
+      background 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
     background: linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0, rgba(0, 0, 0, 1));
     bottom: -70px;
   }
@@ -201,7 +202,7 @@
     width: 100%;
     height: 100%;
     z-index: 2;
-    transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+    transition: opacity 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
     opacity: 0;
   }
 
@@ -216,7 +217,7 @@
 
   &:hover .content {
     bottom: 0;
-    background: transparent;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0));
   }
 
   &:hover .title {
@@ -287,29 +288,36 @@
 .summary-popup {
   position: fixed;
   width: calc(90% - 150px);
-  height: 90dvh;
+  max-height: 80dvh;
+  height: fit-content;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: #edefef;
-  padding: 20px;
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: #1e293b;
+  padding: 32px;
+  border: 1px solid #334155;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   z-index: 1000;
-  overflow: scroll;
+  overflow: auto;
   scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .close-summary-popup-icon {
   display: block;
-  position: sticky;
-  float: right;
-  top: 0;
-  right: 0;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 1.25rem;
 
   &:hover {
-    color: #cc0707;
+    color: #ef4444;
   }
 }
 
@@ -318,18 +326,59 @@
 }
 
 .summary-title {
-  font-size: 3rem;
-  margin-top: 3rem;
-  clear: both;
+  color: #f1f5f9;
+  font-size: 2.25rem;
+  font-weight: 700;
+  font-family: sans-serif;
+  margin: 0 0 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #334155;
 }
 
 .summary-section {
-  text-align: initial;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 0 3rem;
-  font-size: 2rem;
+  color: #e2e8f0;
+  font-size: 1.4rem;
+  font-weight: 400;
   font-family: sans-serif;
+  line-height: 1.7;
+  padding: 0;
+  text-align: initial;
+
+  h2, h3 {
+    color: #f59e0b;
+    font-family: sans-serif;
+    border-left: 3px solid #f59e0b;
+    padding-left: 10px;
+    margin: 20px 0 10px;
+  }
+
+  a {
+    color: #f59e0b;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  code {
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    padding: 2px 6px;
+    color: #e2e8f0;
+    font-size: 0.875em;
+  }
+
+  pre {
+    background: #0f172a;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    padding: 16px;
+    overflow-x: auto;
+    font-size: 0.875rem;
+    color: #e2e8f0;
+  }
 }
 
 @media screen and (max-width: 1200px) {
@@ -354,6 +403,9 @@
       bottom: 0;
     }
 
+    &:hover .content {
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0, rgba(0, 0, 0, 1));
+    }
   }
 }
 
@@ -373,18 +425,25 @@
     }
   }
 
-  .summary-title {
-    font-size: 2rem;
-    margin-top: 2rem;
-  }
-
   .summary-popup {
-    width: calc(100% - 50px);
-    padding: 10px;
+    width: calc(100% - 48px);
+    padding: 20px;
   }
 
-  .summary-section {
-    padding: 0 1rem;
-    font-size: 1rem;
+  .summary-title {
+    font-size: 1.25rem;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .summary-popup {
+    width: calc(100% - 24px);
+    padding: 16px;
+    border-radius: 12px;
+  }
+
+  .close-summary-popup-icon {
+    top: 12px;
+    right: 12px;
   }
 }


### PR DESCRIPTION
Popup redesign:
  - Switch from light (#edefef) to dark theme (#1e293b) matching site palette
  - Replace float/sticky close icon with position:absolute; muted gray → red on hover
  - Remove anonymous wrapper div, `<hr>`, and invalid `<p>` around parsed HTML
  - Title: 2.25rem, bold, #f1f5f9, border-bottom separator replaces `<hr>`
  - Body: 1.4rem, weight 400, #e2e8f0, line-height 1.7
  - Scoped styles for parsed HTML headings (amber accent), links, code/pre blocks
  - fit-content height capped at 80dvh; hidden scrollbar; deeper box-shadow
  - Responsive: full-width at ≤800px, tighter padding at ≤480px

  Card hover fixes:
  - Scope ::after transition to opacity only; content transition to bottom +
    background only — prevents layout recomposition artifacts causing white
    line flicker at the border-radius clip boundary
  - Use gradient-to-zero-gradient on hover background so CSS can interpolate
    smoothly instead of jumping to transparent
  - On ≤1200px, lock hover background to the same dark gradient so the
    always-visible content stays readable and no flash occurs

Issue: #102 