### PR TITLE
fix(home): show nav-bar on mobile first visit by scrolling to top

### DIFF
--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -43,7 +43,11 @@ const Layout = () => {
     const behavior = isFirstRender.current ? "auto" : "smooth";
     isFirstRender.current = false;
     setTimeout(() => {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior });
+      if (sectionId === "home") {
+        window.scrollTo({ top: 0, behavior });
+      } else {
+        document.getElementById(sectionId)?.scrollIntoView({ behavior });
+      }
     }, 50);
   }, [location.pathname]);
 


### PR DESCRIPTION
Use window.scrollTo(top:0) for home navigation so the mobile nav-bar stays in view instead of being scrolled past by scrollIntoView. Also add min-height: 100dvh fallback for correct viewport sizing on mobile.

Issue: #98 