### PR TITLE
feat(art-gallery): add arrow navigation and swipe/trackpad gestures to popup

### DIFF
--- a/src/components/ArtGallery/index.js
+++ b/src/components/ArtGallery/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import AnimatedLetters from "../AnimatedLetters";
 import "./index.scss";
 import artCategories from "../../data/arts";
-import { faClose } from "@fortawesome/free-solid-svg-icons";
+import { faClose, faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const ArtGallery = () => {
@@ -11,7 +11,11 @@ const ArtGallery = () => {
   const [showPopup, setShowPopup] = useState(false);
   const [showFullImage, setShowFullImage] = useState(false);
   const [showKey, setShowKey] = useState(0);
+  const [slideDirection, setSlideDirection] = useState('right');
   const popupRef = useRef(null);
+  const touchStartXRef = useRef(null);
+  const wheelCooldownRef = useRef(false);
+  const wheelResetTimerRef = useRef(null);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -36,24 +40,72 @@ const ArtGallery = () => {
     }
 
     // If popup is opened and Esc key is pressed then close the popup
+    // Arrow keys navigate between paintings
     function handleEscKey(event) {
       if (event.key === 'Escape' && showPopup) {
         closePopup();
+      } else if (event.key === 'ArrowRight' && showPopup) {
+        navigateNext();
+      } else if (event.key === 'ArrowLeft' && showPopup) {
+        navigatePrev();
       }
+    }
+
+    function handleWheel(event) {
+      if (Math.abs(event.deltaX) < Math.abs(event.deltaY)) return;
+      event.preventDefault();
+      if (wheelCooldownRef.current) {
+        // Keep pushing out the reset while gesture is still active
+        clearTimeout(wheelResetTimerRef.current);
+        wheelResetTimerRef.current = setTimeout(() => {
+          wheelCooldownRef.current = false;
+        }, 400);
+        return;
+      }
+      wheelCooldownRef.current = true;
+      wheelResetTimerRef.current = setTimeout(() => {
+        wheelCooldownRef.current = false;
+      }, 400);
+      event.deltaX > 0 ? navigateNext() : navigatePrev();
     }
 
     // Only add the event listener when the popup is shown
     if (showPopup) {
       document.addEventListener('mousedown', handleClickOutside);
       document.addEventListener('keydown', handleEscKey);
+      document.addEventListener('wheel', handleWheel, { passive: false });
     }
 
     // Clean up the event listener
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleEscKey);
+      document.removeEventListener('wheel', handleWheel);
     };
-  }, [showPopup]);
+  }, [showPopup, art.length]);
+
+  const navigateNext = () => {
+    setSlideDirection('right');
+    setShowKey((prev) => (prev + 1) % art.length);
+  };
+
+  const navigatePrev = () => {
+    setSlideDirection('left');
+    setShowKey((prev) => (prev - 1 + art.length) % art.length);
+  };
+
+  const handleTouchStart = (e) => {
+    touchStartXRef.current = e.touches[0].clientX;
+  };
+
+const handleTouchEnd = (e) => {
+    if (touchStartXRef.current === null) return;
+    const delta = touchStartXRef.current - e.changedTouches[0].clientX;
+    if (Math.abs(delta) > 50) {
+      delta > 0 ? navigateNext() : navigatePrev();
+    }
+    touchStartXRef.current = null;
+  };
 
   // Function to close popup and clean URL
   const closePopup = () => {
@@ -106,7 +158,12 @@ const ArtGallery = () => {
           <img src={art[showKey]?.image} alt={"art"} className="art-lightbox-img" />
         </div>
       )}
-      <div className={showPopup ? "art-popup" : "popup-disabled"} ref={popupRef}>
+      <div
+        className={showPopup ? "art-popup" : "popup-disabled"}
+        ref={popupRef}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
         <div>
           <FontAwesomeIcon
             onClick={closePopup}
@@ -115,14 +172,24 @@ const ArtGallery = () => {
             size={"lg"}
             className={showPopup ? "close-popup-icon" : ""}
           />
-          <h1>{art[showKey]?.name}</h1>
+          <h1 key={`title-${showKey}`} className={`art-slide-in-${slideDirection}`}>{art[showKey]?.name}</h1>
           <div className={"arts-section"}>
             <img
+              key={showKey}
               src={art[showKey]?.image}
               alt={"art"}
-              className={"art-full-popup"}
+              className={`art-full-popup art-slide-in-${slideDirection}`}
               onClick={() => setShowFullImage(true)}
             />
+          </div>
+          <div className="art-nav">
+            <button className="art-nav-btn" onClick={navigatePrev} aria-label="Previous painting">
+              <FontAwesomeIcon icon={faChevronLeft} />
+            </button>
+            <span className="art-nav-counter">{showKey + 1} / {art.length}</span>
+            <button className="art-nav-btn" onClick={navigateNext} aria-label="Next painting">
+              <FontAwesomeIcon icon={faChevronRight} />
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -194,6 +194,79 @@
   }
 }
 
+.art-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  margin-top: 18px;
+}
+
+.art-nav-btn {
+  position: relative;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.18) 0%,
+    rgba(255, 255, 255, 0.06) 100%
+  );
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  transition: all 0.25s ease;
+  overflow: hidden;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: radial-gradient(
+      ellipse at 40% 30%,
+      rgba(255, 255, 255, 0.25) 0%,
+      transparent 65%
+    );
+    pointer-events: none;
+  }
+
+  &:hover {
+    background: linear-gradient(
+      135deg,
+      rgba(255, 215, 0, 0.45) 0%,
+      rgba(255, 215, 0, 0.15) 100%
+    );
+    border-color: rgba(255, 215, 0, 0.6);
+    color: #ffd700;
+    box-shadow:
+      0 6px 24px rgba(255, 215, 0, 0.25),
+      inset 0 1px 0 rgba(255, 255, 255, 0.4),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+    transform: scale(1.08);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+}
+
+.art-nav-counter {
+  color: #64748b;
+  font-size: 0.9rem;
+  min-width: 50px;
+  text-align: center;
+}
+
 .close-popup-icon {
   display: block;
   position: absolute;
@@ -236,6 +309,26 @@
   max-height: 100dvh;
   object-fit: contain;
   border-radius: 4px;
+}
+
+@keyframes pageFlipInRight {
+  0%   { opacity: 0; transform: perspective(1200px) rotateY(-25deg) translateX(40px) scale(0.95); }
+  100% { opacity: 1; transform: perspective(1200px) rotateY(0deg)  translateX(0)    scale(1); }
+}
+
+@keyframes pageFlipInLeft {
+  0%   { opacity: 0; transform: perspective(1200px) rotateY(25deg)  translateX(-40px) scale(0.95); }
+  100% { opacity: 1; transform: perspective(1200px) rotateY(0deg)   translateX(0)     scale(1); }
+}
+
+.art-slide-in-right {
+  animation: pageFlipInRight 0.5s cubic-bezier(0.33, 1, 0.68, 1) both;
+  will-change: transform, opacity;
+}
+
+.art-slide-in-left {
+  animation: pageFlipInLeft 0.5s cubic-bezier(0.33, 1, 0.68, 1) both;
+  will-change: transform, opacity;
 }
 
 .art-full-popup {


### PR DESCRIPTION
## Implementation
- Left/right chevron buttons with liquid glass styling and page counter
- Keyboard arrow key navigation (← →)
- Mobile touch swipe support
- Trackpad two-finger swipe support with debounced cooldown to prevent double-skip on a single gesture
- Page-flip 3D animation on image and title transition

## Issue:
#112 