### PR TITLE
feat(art-gallery): replace view button with click-on-image to open popup

### DIFF
--- a/src/components/ArtGallery/index.js
+++ b/src/components/ArtGallery/index.js
@@ -124,7 +124,14 @@ const handleTouchEnd = (e) => {
       <div className="images-container">
         {arts.map((port, idx) => {
           return (
-            <div className="image-box" key={idx}>
+            <div
+              className="image-box"
+              key={idx}
+              onClick={() => {
+                setShowKey(idx);
+                setShowPopup(true);
+              }}
+            >
               <img src={port.image} className="art-image" alt="art" />
               <div className="image-date">
                 <p>{port.creationDate}</p>
@@ -132,17 +139,6 @@ const handleTouchEnd = (e) => {
               <div className="content">
                 <p className="title">{port.name}</p>
                 <h4 className="description">{port.description}</h4>
-                <div className="button-container">
-                  <button
-                    className="btn"
-                    onClick={() => {
-                      setShowKey(idx);
-                      setShowPopup(true);
-                    }}
-                  >
-                    View
-                  </button>
-                </div>
               </div>
             </div>
           );

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -35,6 +35,7 @@
     overflow: hidden;
     border-radius: 10px;
     max-width: calc(25% - 10px);
+    cursor: pointer;
 
     .art-image {
       position: absolute;
@@ -90,39 +91,6 @@
       padding: 5px 10px;
       line-height: 0;
       backdrop-filter: blur(1rem) saturate(160%)
-    }
-
-    .btn {
-      margin-top: 30px;
-      margin-bottom: 10px;
-      padding: 0 23px;
-      height: 40px;
-      line-height: 34px;
-      border: 2px solid #ffd700;
-      border-radius: 4px;
-      font-size: 14px;
-      color: #fff;
-      background: transparent;
-      text-transform: uppercase;
-      font-weight: 700;
-      transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
-      cursor: pointer;
-    }
-
-    .btn:hover {
-      transform: translateY(-3px);
-      background: #ffd700;
-    }
-
-    .button-container {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      justify-content: space-evenly;
-
-      a {
-        text-decoration: none;
-      }
     }
 
     &:after {


### PR DESCRIPTION
## Implementation
- Remove the explicit View button in favour of clicking the card directly.
- Adds cursor: pointer to the image box and removes now-unused button styles.


## Issue
#119 