### PR TITLE
feat(skills): replace view button with click-on-card to open popup

### DIFF
--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -70,21 +70,17 @@ const Skills = () => {
       <div className="images-container">
         {skills.map((port, idx) => {
           return (
-            <div className="image-box" key={idx}>
+            <div
+              className="image-box"
+              key={idx}
+              onClick={() => {
+                setShowKey(idx);
+                setShowPopup(true);
+              }}
+            >
               <img src={port.image} className="skill-image" alt="skill" />
               <div className="content">
                 <p className="title">{port.name}</p>
-                <div className="button-container">
-                  <button
-                    className="btn"
-                    onClick={() => {
-                      setShowKey(idx);
-                      setShowPopup(true);
-                    }}
-                  >
-                    View
-                  </button>
-                </div>
               </div>
             </div>
           );

--- a/src/components/Skills/index.scss
+++ b/src/components/Skills/index.scss
@@ -47,62 +47,33 @@
       left: 0;
     }
 
+    cursor: pointer;
+
     .content {
       position: absolute;
-      width: calc(100% - 40px);
+      width: 100%;
       z-index: 3;
-      padding: 10px 20px;
+      padding: 2rem 1.25rem 0.75rem;
       transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
-      background: linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0, rgba(0, 0, 0, 1));
-      bottom: -70px;
+      background: linear-gradient(
+        180deg,
+        transparent 0%,
+        rgba(0, 0, 0, 0.85) 40%,
+        rgba(0, 0, 0, 1) 100%
+      );
+      bottom: 0;
     }
 
     .title {
       margin-bottom: 0;
       margin-top: 0;
       color: #fff;
-      font-size: 22px;
+      font-size: 1.75rem;
       font-weight: 600;
-      line-height: 26px;
+      line-height: 2rem;
       white-space: normal;
       overflow: visible;
       word-break: break-word;
-    }
-
-    .btn {
-      margin-top: 20px;
-      margin-bottom: 10px;
-      padding: 0 20px;
-      height: 38px;
-      line-height: 36px;
-      border: 1.5px solid #f59e0b;
-      border-radius: 8px;
-      font-size: 13px;
-      color: #f59e0b;
-      background: transparent;
-      text-transform: uppercase;
-      font-weight: 700;
-      letter-spacing: 0.05em;
-      transition: all 0.25s cubic-bezier(0.645, 0.045, 0.355, 1);
-      cursor: pointer;
-
-      &:hover {
-        transform: translateY(-2px);
-        background: #f59e0b;
-        color: #0f172a;
-        box-shadow: 0 4px 12px rgba(245, 158, 11, 0.35);
-      }
-    }
-
-    .button-container {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      justify-content: space-evenly;
-
-      a {
-        text-decoration: none;
-      }
     }
 
     &:after {
@@ -131,7 +102,12 @@
 
     &:hover .content {
       bottom: 0;
-      background: transparent;
+      background: linear-gradient(
+        180deg,
+        transparent 0%,
+        rgba(0, 0, 0, 0.6) 40%,
+        rgba(0, 0, 0, 0.85) 100%
+      );
     }
   }
 }


### PR DESCRIPTION
## implementation
Remove the explicit View button in favour of clicking the card directly.
Applies the same transparent-to-black gradient, 1.75rem title font, rem units, and cursor: pointer as the art gallery cards.

## Issue
#122 