### PR TITLE
refactor(styles): centralise colour palette into CSS custom properties

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -37,8 +37,6 @@
   }
 }
 
-$primary-color: #f59e0b;
-
 @import "animate.css";
 
 @font-face {

--- a/src/components/AnimatedLetters/index.scss
+++ b/src/components/AnimatedLetters/index.scss
@@ -13,7 +13,7 @@
 
   &:hover {
     animation: rubberBand 1s;
-    color: #f59e0b;
+    color: var(--color-accent);
   }
 }
 

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -7,7 +7,7 @@
   overflow: auto;
 
   h1 {
-    color: #f59e0b;
+    color: var(--color-accent);
     font-size: 53px;
     margin: 0;
     font-family: "Coolvetica", sans-serif;
@@ -96,7 +96,7 @@
 
     &:after {
       content: "";
-      background: linear-gradient(180deg, #f59e0b, #000);
+      background: linear-gradient(180deg, var(--color-accent), #000);
       position: absolute;
       left: 0;
       right: 0;
@@ -143,9 +143,9 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: #1e293b;
+  background-color: var(--color-bg-surface);
   padding: 28px;
-  border: 1px solid #334155;
+  border: 1px solid var(--color-border);
   border-radius: 16px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
   z-index: 1000;
@@ -157,13 +157,13 @@
   }
 
   h1 {
-    color: #f1f5f9;
+    color: var(--color-text-primary);
     font-size: 2rem;
     font-weight: 700;
     font-family: sans-serif;
     margin: 0 0 20px;
     padding-bottom: 16px;
-    border-bottom: 1px solid #334155;
+    border-bottom: 1px solid var(--color-border);
     text-align: center;
   }
 }
@@ -217,13 +217,13 @@
   &:hover {
     background: linear-gradient(
       135deg,
-      rgba(245, 158, 11, 0.45) 0%,
-      rgba(245, 158, 11, 0.15) 100%
+      rgba(var(--color-accent-rgb), 0.45) 0%,
+      rgba(var(--color-accent-rgb), 0.15) 100%
     );
-    border-color: rgba(245, 158, 11, 0.6);
-    color: #f59e0b;
+    border-color: rgba(var(--color-accent-rgb), 0.6);
+    color: var(--color-accent);
     box-shadow:
-      0 6px 24px rgba(245, 158, 11, 0.25),
+      0 6px 24px rgba(var(--color-accent-rgb), 0.25),
       inset 0 1px 0 rgba(255, 255, 255, 0.4),
       inset 0 -1px 0 rgba(0, 0, 0, 0.1);
     transform: scale(1.08);
@@ -235,7 +235,7 @@
 }
 
 .art-nav-counter {
-  color: #64748b;
+  color: var(--color-text-subtle);
   font-size: 0.9rem;
   min-width: 50px;
   text-align: center;
@@ -247,12 +247,12 @@
   top: 1rem;
   right: 1rem;
   font-size: 1.5rem;
-  color: #94a3b8;
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: color 0.2s ease;
 
   &:hover {
-    color: #ef4444;
+    color: var(--color-danger);
   }
 }
 

--- a/src/components/Career/index.js
+++ b/src/components/Career/index.js
@@ -16,20 +16,20 @@ import VelotioLogo from "../../assets/images/career/velotio_logo.svg";
 import MaxIQLogo from "../../assets/images/career/getmaxiq_logo.png";
 
 const dotSx = {
-  borderColor: "#334155",
-  bgcolor: "#0d1f33",
+  borderColor: "var(--color-border)",
+  bgcolor: "var(--color-bg-dot)",
   boxShadow: "none",
   padding: "6px",
 };
 
 const activeDotSx = {
-  borderColor: "#f59e0b",
-  bgcolor: "#0d1f33",
+  borderColor: "var(--color-accent)",
+  bgcolor: "var(--color-bg-dot)",
   boxShadow: "none",
   padding: "6px",
 };
 
-const connectorSx = { bgcolor: "#334155" };
+const connectorSx = { bgcolor: "var(--color-border)" };
 
 const Career = () => {
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);

--- a/src/components/Career/index.scss
+++ b/src/components/Career/index.scss
@@ -7,7 +7,7 @@
   overflow: auto;
 
   h1 {
-    color: #f59e0b;
+    color: var(--color-accent);
     font-size: 53px;
     margin: 0;
     font-family: "Coolvetica", sans-serif;
@@ -28,10 +28,10 @@
   }
 
   .timeline-entry-card {
-    background: #1e293b;
+    background: var(--color-bg-surface);
     border-radius: 12px;
     padding: 16px 20px;
-    border: 1px solid #334155;
+    border: 1px solid var(--color-border);
     transition: border-color 0.25s, transform 0.25s, box-shadow 0.25s;
     display: inline-block;
     width: 100%;
@@ -39,7 +39,7 @@
     text-align: left;
 
     &:hover {
-      border-color: #f59e0b;
+      border-color: var(--color-accent);
       transform: translateY(-2px);
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
     }
@@ -47,13 +47,13 @@
 
   .position-title {
     font-weight: 700;
-    color: #f1f5f9;
+    color: var(--color-text-primary);
     display: block;
     margin-bottom: 4px;
   }
 
   .position-company {
-    color: #f59e0b;
+    color: var(--color-accent);
     font-size: 14px;
     font-weight: 500;
     display: block;
@@ -63,19 +63,19 @@
   .date-pill {
     display: inline-block;
     background: rgba(51, 65, 85, 0.6);
-    color: #94a3b8;
+    color: var(--color-text-muted);
     font-size: 12px;
     font-weight: 500;
     padding: 3px 10px;
     border-radius: 20px;
-    border: 1px solid #334155;
+    border: 1px solid var(--color-border);
     margin-bottom: 4px;
     white-space: nowrap;
   }
 
   .position-extra {
     display: block;
-    color: #64748b;
+    color: var(--color-text-subtle);
     font-size: 12px;
     margin-top: 4px;
     margin-bottom: 8px;
@@ -86,24 +86,24 @@
   }
 
   .fading-timeline-connector {
-    background: linear-gradient(to bottom, #334155, rgba(51, 65, 85, 0)) !important;
+    background: linear-gradient(to bottom, var(--color-border), rgba(51, 65, 85, 0)) !important;
   }
 
   @keyframes pulse-ring {
     0% {
-      box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.5);
+      box-shadow: 0 0 0 0 rgba(var(--color-accent-rgb), 0.5);
     }
     70% {
-      box-shadow: 0 0 0 8px rgba(245, 158, 11, 0);
+      box-shadow: 0 0 0 8px rgba(var(--color-accent-rgb), 0);
     }
     100% {
-      box-shadow: 0 0 0 0 rgba(245, 158, 11, 0);
+      box-shadow: 0 0 0 0 rgba(var(--color-accent-rgb), 0);
     }
   }
 
   .active-dot {
     animation: pulse-ring 2s ease-out infinite;
-    border-color: #f59e0b !important;
+    border-color: var(--color-accent) !important;
   }
 }
 

--- a/src/components/Contact/index.scss
+++ b/src/components/Contact/index.scss
@@ -35,7 +35,7 @@
   input[type="email"] {
     width: 100%;
     border: 0;
-    background: #1e293b;
+    background: var(--color-bg-surface);
     height: 50px;
     font-size: 16px;
     color: #fff;
@@ -46,7 +46,7 @@
   textarea {
     width: 100%;
     border: 0;
-    background: #1e293b;
+    background: var(--color-bg-surface);
     height: 50px;
     font-size: 16px;
     color: #fff;
@@ -56,12 +56,12 @@
   }
 
   .flat-button {
-    color: #f59e0b;
+    color: var(--color-accent);
     background: 0 0;
     letter-spacing: 3px;
     text-decoration: none;
     padding: 8px 10px;
-    border: 1px solid #f59e0b;
+    border: 1px solid var(--color-accent);
     float: right;
     border-radius: 4px;
   }

--- a/src/components/Home/Logo/index.scss
+++ b/src/components/Home/Logo/index.scss
@@ -32,6 +32,6 @@
 }
 
 .svg-container {
-  stroke: #f59e0b;
+  stroke: var(--color-accent);
   stroke-width: 0;
 }

--- a/src/components/Home/index.scss
+++ b/src/components/Home/index.scss
@@ -34,7 +34,7 @@
       .standout-text {
         font-size: 20px;
         font-weight: 400;
-        color: #f59e0b;
+        color: var(--color-accent);
       }
     }
   }
@@ -58,7 +58,7 @@
 }
 
 h2 {
-  color: #64748b;
+  color: var(--color-text-subtle);
   margin-top: 20px;
   font-weight: 40;
   font-size: 12px;
@@ -68,22 +68,22 @@ h2 {
 }
 
 .flat-button {
-  color: #f59e0b;
+  color: var(--color-accent);
   font-size: 13px;
   font-weight: 400;
   letter-spacing: 4px;
   font-family: sans-serif;
   text-decoration: none;
   padding: 10px 18px;
-  border: 1px solid #f59e0b;
+  border: 1px solid var(--color-accent);
   margin-top: 25px;
   float: left;
   animation: fadeIn 1s 1.8s backwards;
   white-space: nowrap;
 
   &:hover {
-    background: #f59e0b;
-    color: #0f172a;
+    background: var(--color-accent);
+    color: var(--color-bg);
   }
 }
 

--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -33,7 +33,7 @@
     h1 {
       font-size: 53px;
       font-family: "Coolvetica", "sans-serif";
-      color: #f59e0b;
+      color: var(--color-accent);
       font-weight: 400;
       margin-top: 0;
       position: relative;
@@ -65,7 +65,7 @@
     .standout-text {
       font-size: 20px;
       font-weight: 400;
-      color: #f59e0b;
+      color: var(--color-accent);
     }
   }
 
@@ -140,7 +140,7 @@
     padding-bottom: 80px;
 
     & + .scroll-section {
-      border-top: 1px solid rgba(245, 158, 11, 0.08);
+      border-top: 1px solid rgba(var(--color-accent-rgb), 0.08);
     }
   }
 }

--- a/src/components/PaperShelf/index.js
+++ b/src/components/PaperShelf/index.js
@@ -182,8 +182,8 @@ const PaperShelf = () => {
                           }
                         : {
                             flex: 1,
-                            backgroundColor: "rgba(245,158,11,0.2)",
-                            "& .MuiLinearProgress-bar": { backgroundColor: "#f59e0b" },
+                            backgroundColor: "rgba(var(--color-accent-rgb),0.2)",
+                            "& .MuiLinearProgress-bar": { backgroundColor: "var(--color-accent)" },
                           }
                     }
                   />

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -7,7 +7,7 @@
   overflow: auto;
 
   h1 {
-    color: #f59e0b;
+    color: var(--color-accent);
     font-size: 53px;
     margin: 0;
     font-family: "Coolvetica", sans-serif;
@@ -29,33 +29,33 @@
   }
 
   .content-sections {
-    background-color: #1e293b;
+    background-color: var(--color-bg-surface);
     transition: background-color 0.2s;
 
     h3 {
-      color: #e2e8f0;
+      color: var(--color-text-secondary);
       margin: 0;
     }
 
     .expand-icon {
-      color: #94a3b8;
+      color: var(--color-text-muted);
     }
 
     &:hover {
-      background-color: #253347;
+      background-color: var(--color-bg-surface-hover);
 
       h3 {
-        color: #f1f5f9;
+        color: var(--color-text-primary);
       }
 
       .expand-icon {
-        color: #f1f5f9;
+        color: var(--color-text-primary);
       }
     }
   }
 
   .content-details {
-    background-color: #0f172a;
+    background-color: var(--color-bg);
     padding: 16px 24px 24px;
   }
 }
@@ -74,7 +74,7 @@
   overflow: hidden;
   border-radius: 12px;
   max-width: calc(33.3% - 10px);
-  background: linear-gradient(180deg, #1e293b, #000);
+  background: linear-gradient(180deg, var(--color-bg-surface), #000);
   transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1),
     box-shadow 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 
@@ -113,7 +113,7 @@
   .description {
     font-size: 14px;
     margin-bottom: 5px;
-    color: #cbd5e1;
+    color: var(--color-text-tertiary);
     font-weight: 600;
   }
 
@@ -134,7 +134,7 @@
   .authors {
     font-size: 13px;
     margin-bottom: 5px;
-    color: #94a3b8;
+    color: var(--color-text-muted);
     font-weight: 500;
   }
 
@@ -146,10 +146,10 @@
     padding: 0 18px;
     height: 38px;
     line-height: 36px;
-    border: 1.5px solid #f59e0b;
+    border: 1.5px solid var(--color-accent);
     border-radius: 8px;
     font-size: 13px;
-    color: #f59e0b;
+    color: var(--color-accent);
     background: transparent;
     text-transform: uppercase;
     font-weight: 700;
@@ -165,15 +165,15 @@
   .btn-disabled {
     cursor: not-allowed;
     pointer-events: none;
-    border: 1.5px solid #334155;
-    color: #475569;
+    border: 1.5px solid var(--color-border);
+    color: var(--color-text-faint);
   }
 
   .btn:hover {
     transform: translateY(-2px);
-    background: #f59e0b;
-    color: #0f172a;
-    box-shadow: 0 4px 12px rgba(245, 158, 11, 0.35);
+    background: var(--color-accent);
+    color: var(--color-bg);
+    box-shadow: 0 4px 12px rgba(var(--color-accent-rgb), 0.35);
   }
 
   .btn-name {
@@ -194,7 +194,7 @@
 
   &:after {
     content: "";
-    background: linear-gradient(180deg, rgba(15, 23, 42, 0.6), rgba(0, 0, 0, 0.92));
+    background: linear-gradient(180deg, rgba(var(--color-bg-rgb), 0.6), rgba(0, 0, 0, 0.92));
     position: absolute;
     left: 0;
     right: 0;
@@ -233,7 +233,7 @@
     margin: 0 0 8px;
     display: flex;
     justify-content: flex-start;
-    background: rgba(15, 23, 42, 0.5);
+    background: rgba(var(--color-bg-rgb), 0.5);
     border-radius: 24px;
     width: fit-content;
     overflow: visible;
@@ -248,13 +248,13 @@
   }
 
   .active-action-button {
-    background: #f59e0b;
-    color: #0f172a;
-    box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+    background: var(--color-accent);
+    color: var(--color-bg);
+    box-shadow: 0 2px 8px rgba(var(--color-accent-rgb), 0.4);
 
     &:hover {
-      background: #f59e0b;
-      color: #0f172a;
+      background: var(--color-accent);
+      color: var(--color-bg);
     }
   }
 }
@@ -267,7 +267,7 @@
   border: none;
   border-radius: 20px;
   font-size: 13px;
-  color: #94a3b8;
+  color: var(--color-text-muted);
   background: transparent;
   text-transform: uppercase;
   font-weight: 700;
@@ -276,7 +276,7 @@
   cursor: pointer;
 
   &:hover {
-    color: #e2e8f0;
+    color: var(--color-text-secondary);
     background: rgba(255, 255, 255, 0.08);
   }
 }
@@ -294,9 +294,9 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: #1e293b;
+  background-color: var(--color-bg-surface);
   padding: 32px;
-  border: 1px solid #334155;
+  border: 1px solid var(--color-border);
   border-radius: 16px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   z-index: 1000;
@@ -314,12 +314,12 @@
   top: 1rem;
   right: 1rem;
   cursor: pointer;
-  color: #94a3b8;
+  color: var(--color-text-muted);
   font-size: 1.5rem;
   transition: color 0.2s ease;
 
   &:hover {
-    color: #ef4444;
+    color: var(--color-danger);
   }
 }
 
@@ -328,17 +328,17 @@
 }
 
 .summary-title {
-  color: #f1f5f9;
+  color: var(--color-text-primary);
   font-size: 2.25rem;
   font-weight: 700;
   font-family: sans-serif;
   margin: 0 0 20px;
   padding-bottom: 16px;
-  border-bottom: 1px solid #334155;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .summary-section {
-  color: #e2e8f0;
+  color: var(--color-text-secondary);
   font-size: 1.4rem;
   font-weight: 400;
   font-family: sans-serif;
@@ -347,15 +347,15 @@
   text-align: initial;
 
   h2, h3 {
-    color: #f59e0b;
+    color: var(--color-accent);
     font-family: sans-serif;
-    border-left: 3px solid #f59e0b;
+    border-left: 3px solid var(--color-accent);
     padding-left: 10px;
     margin: 20px 0 10px;
   }
 
   a {
-    color: #f59e0b;
+    color: var(--color-accent);
     text-decoration: none;
 
     &:hover {
@@ -364,22 +364,22 @@
   }
 
   code {
-    background: #0f172a;
-    border: 1px solid #334155;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
     border-radius: 4px;
     padding: 2px 6px;
-    color: #e2e8f0;
+    color: var(--color-text-secondary);
     font-size: 0.875em;
   }
 
   pre {
-    background: #0f172a;
-    border: 1px solid #334155;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
     border-radius: 8px;
     padding: 16px;
     overflow-x: auto;
     font-size: 0.875rem;
-    color: #e2e8f0;
+    color: var(--color-text-secondary);
   }
 }
 

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -51,52 +51,52 @@ const Sidebar = () => {
           className={isActive("/") ? "active" : ""}
           onClick={(e) => handleNavClick(e, "home", "/")}
         >
-          <FontAwesomeIcon icon={faHome} color="#4d4d4e" />
+          <FontAwesomeIcon icon={faHome} color="var(--color-icon-muted)" />
         </a>
         {/*Hidden About section because the about section content has been*/}
         {/*moved to home page*/}
         {/*<a href="#about" className={`about-link${isActive("/about") ? " active" : ""}`} onClick={(e) => handleNavClick(e, "about", "/about")}>*/}
-        {/*  <FontAwesomeIcon icon={faUser} color="#4d4d4e" />*/}
+        {/*  <FontAwesomeIcon icon={faUser} color="var(--color-icon-muted)" />*/}
         {/*</a>*/}
         <a
           href="#skills"
           className={`skills-link${isActive("/skills") ? " active" : ""}`}
           onClick={(e) => handleNavClick(e, "skills", "/skills")}
         >
-          <FontAwesomeIcon icon={faCogs} color="#4d4d4e" />
+          <FontAwesomeIcon icon={faCogs} color="var(--color-icon-muted)" />
         </a>
         <a
           href="#career"
           className={`career-link${isActive("/career") ? " active" : ""}`}
           onClick={(e) => handleNavClick(e, "career", "/career")}
         >
-          <FontAwesomeIcon icon={faBriefcase} color="#4d4d4e" />
+          <FontAwesomeIcon icon={faBriefcase} color="var(--color-icon-muted)" />
         </a>
         <a
           href="#paper-shelf"
           className={`paper-shelf-link${isActive("/paper-shelf") ? " active" : ""}`}
           onClick={(e) => handleNavClick(e, "paper-shelf", "/paper-shelf")}
         >
-          <FontAwesomeIcon icon={faBook} color="#4d4d4e" />
+          <FontAwesomeIcon icon={faBook} color="var(--color-icon-muted)" />
         </a>
         <a
           href="#art-gallery"
           className={`art-gallery-link${isActive("/art-gallery") ? " active" : ""}`}
           onClick={(e) => handleNavClick(e, "art-gallery", "/art-gallery")}
         >
-          <FontAwesomeIcon icon={faImages} color="#4d4d4e" />
+          <FontAwesomeIcon icon={faImages} color="var(--color-icon-muted)" />
         </a>
         <a
           href="#contact"
           className={`contact-link${isActive("/contact") ? " active" : ""}`}
           onClick={(e) => handleNavClick(e, "contact", "/contact")}
         >
-          <FontAwesomeIcon icon={faEnvelope} color="#4d4d4e" />
+          <FontAwesomeIcon icon={faEnvelope} color="var(--color-icon-muted)" />
         </a>
         <FontAwesomeIcon
           onClick={() => setShowNav(false)}
           icon={faClose}
-          color={"#ffd700"}
+          color={"var(--color-accent)"}
           size={"3x"}
           className={"close-icon"}
         />
@@ -109,7 +109,7 @@ const Sidebar = () => {
               rel={"noreferrer"}
               href={"https://linkedin.com/in/ankushchavan"}
             >
-              <FontAwesomeIcon icon={faLinkedin} color={"#4d4d4e"} />
+              <FontAwesomeIcon icon={faLinkedin} color={"var(--color-icon-muted)"} />
             </a>
           </li>
           <li>
@@ -118,7 +118,7 @@ const Sidebar = () => {
               rel={"noreferrer"}
               href={"https://github.com/cankush625"}
             >
-              <FontAwesomeIcon icon={faGithub} color={"#4d4d4e"} />
+              <FontAwesomeIcon icon={faGithub} color={"var(--color-icon-muted)"} />
             </a>
           </li>
           <li>
@@ -127,7 +127,7 @@ const Sidebar = () => {
               rel={"noreferrer"}
               href={"https://ankush-chavan.medium.com/"}
             >
-              <FontAwesomeIcon icon={faMedium} color={"#4d4d4e"} />
+              <FontAwesomeIcon icon={faMedium} color={"var(--color-icon-muted)"} />
             </a>
           </li>
           <li>
@@ -136,7 +136,7 @@ const Sidebar = () => {
               rel={"noreferrer"}
               href={"https://twitter.com/TheNameIsAnkush"}
             >
-              <FontAwesomeIcon icon={faTwitter} color={"#4d4d4e"} />
+              <FontAwesomeIcon icon={faTwitter} color={"var(--color-icon-muted)"} />
             </a>
           </li>
           {SHOW_INSTAGRAM && (
@@ -146,7 +146,7 @@ const Sidebar = () => {
                 rel={"noreferrer"}
                 href={"https://instagram.com/ankushchavan_"}
               >
-                <FontAwesomeIcon icon={faInstagram} color={"#4d4d4e"} />
+                <FontAwesomeIcon icon={faInstagram} color={"var(--color-icon-muted)"} />
               </a>
             </li>
           )}
@@ -155,7 +155,7 @@ const Sidebar = () => {
       <FontAwesomeIcon
         onClick={() => setShowNav(true)}
         icon={faBars}
-        color={"#ffd700"}
+        color={"var(--color-accent)"}
         size={"3x"}
         className={"hamburger-icon"}
       />

--- a/src/components/Sidebar/index.scss
+++ b/src/components/Sidebar/index.scss
@@ -1,5 +1,5 @@
 .nav-bar {
-  background: #0d1526;
+  background: var(--color-bg-sidebar);
   width: 60px;
   height: 100%;
   position: fixed;
@@ -34,7 +34,7 @@
 
     a {
       font-size: 22px;
-      color: #475569;
+      color: var(--color-text-faint);
       display: block;
       line-height: 51px;
       height: 51px;
@@ -46,7 +46,7 @@
       }
 
       &:hover {
-        color: #f59e0b;
+        color: var(--color-accent);
 
         svg {
           opacity: 0;
@@ -123,7 +123,7 @@
 
     a.active {
       svg {
-        color: #f59e0b !important;
+        color: var(--color-accent) !important;
       }
     }
   }
@@ -146,7 +146,7 @@
         line-height: 16px;
 
         &:hover svg {
-          color: #f59e0b;
+          color: var(--color-accent);
         }
       }
     }
@@ -173,7 +173,7 @@
     nav {
       width: 100%;
       height: 100%;
-      background: #0d1526;
+      background: var(--color-bg-sidebar);
       top: 0;
       left: 0;
       position: fixed;
@@ -229,7 +229,7 @@
       left: 50%;
       transform: translateX(-50%);
       pointer-events: auto;
-      background: rgba(13, 21, 38, 0.5);
+      background: rgba(var(--color-bg-sidebar-rgb), 0.5);
       backdrop-filter: blur(20px);
       -webkit-backdrop-filter: blur(20px);
       border-radius: 40px;
@@ -243,11 +243,11 @@
         padding: 6px 8px;
 
         svg {
-          color: #64748b;
+          color: var(--color-text-subtle);
         }
 
         &:hover svg {
-          color: #f59e0b;
+          color: var(--color-accent);
         }
       }
     }

--- a/src/components/Skills/index.scss
+++ b/src/components/Skills/index.scss
@@ -7,7 +7,7 @@
   overflow: auto;
 
   h1 {
-    color: #f59e0b;
+    color: var(--color-accent);
     font-size: 53px;
     margin: 0;
     font-family: "Coolvetica", sans-serif;
@@ -78,7 +78,7 @@
 
     &:after {
       content: "";
-      background: linear-gradient(180deg, rgba(15, 23, 42, 0.5), rgba(0, 0, 0, 0.92));
+      background: linear-gradient(180deg, rgba(var(--color-bg-rgb), 0.5), rgba(0, 0, 0, 0.92));
       position: absolute;
       left: 0;
       right: 0;
@@ -125,9 +125,9 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: #1e293b;
+  background-color: var(--color-bg-surface);
   padding: 32px;
-  border: 1px solid #334155;
+  border: 1px solid var(--color-border);
   border-radius: 16px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   z-index: 1000;
@@ -139,12 +139,12 @@
   }
 
   h1 {
-    color: #f1f5f9;
+    color: var(--color-text-primary);
     font-size: 1.5rem;
     font-weight: 700;
     margin: 0 0 20px;
     padding-bottom: 16px;
-    border-bottom: 1px solid #334155;
+    border-bottom: 1px solid var(--color-border);
     font-family: sans-serif;
   }
 }
@@ -155,12 +155,12 @@
   top: 1rem;
   right: 1rem;
   font-size: 1.5rem;
-  color: #94a3b8;
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: color 0.2s ease;
 
   &:hover {
-    color: #ef4444;
+    color: var(--color-danger);
   }
 }
 
@@ -175,12 +175,12 @@
 
 .skills-container {
   h3 {
-    color: #e2e8f0;
+    color: var(--color-text-secondary);
     font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    border-left: 3px solid #f59e0b;
+    border-left: 3px solid var(--color-accent);
     padding-left: 10px;
     margin: 20px 0 12px;
     font-family: sans-serif;
@@ -198,15 +198,15 @@
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  background: #0f172a;
-  border: 1px solid #334155;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 12px 14px;
   transition: border-color 0.2s, transform 0.2s;
   cursor: default;
 
   &:hover {
-    border-color: #f59e0b;
+    border-color: var(--color-accent);
     transform: translateY(-2px);
   }
 }
@@ -217,7 +217,7 @@
 }
 
 .skill-name {
-  color: #94a3b8;
+  color: var(--color-text-muted);
   font-size: 11px;
   font-weight: 500;
   text-align: center;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import "./styles/theme.css";
+
 html {
   font-size: 62.5%;
   scroll-behavior: smooth;
@@ -9,7 +11,7 @@ body {
     300 11px/1.4 "Helvetica Neue",
     "sans-serif";
   color: #444;
-  background: #0f172a;
+  background: var(--color-bg);
   display: block;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,37 @@
+/* ==========================================================
+   Colour Palette — edit ONLY this file to switch themes.
+   All SCSS and JSX pull their colours from these tokens.
+   ========================================================== */
+
+:root {
+  /* --- Backgrounds --- */
+  --color-bg:               #0f172a;   /* page / body */
+  --color-bg-rgb:           15, 23, 42;
+  --color-bg-sidebar:       #0d1526;   /* sidebar */
+  --color-bg-sidebar-rgb:   13, 21, 38;
+  --color-bg-surface:       #1e293b;   /* cards, popups, accordions */
+  --color-bg-surface-hover: #253347;   /* surface hover state */
+  --color-bg-dot:           #0d1f33;   /* timeline dot fill */
+
+  /* --- Accent --- */
+  --color-accent:     #f59e0b;
+  --color-accent-rgb: 245, 158, 11;    /* use as: rgba(var(--color-accent-rgb), 0.5) */
+
+  /* --- Borders --- */
+  --color-border:     #334155;
+
+  /* --- Text --- */
+  --color-text-primary:   #f1f5f9;
+  --color-text-secondary: #e2e8f0;
+  --color-text-tertiary:  #cbd5e1;
+  --color-text-muted:     #94a3b8;
+  --color-text-subtle:    #64748b;
+  --color-text-faint:     #475569;
+
+  /* --- Icons --- */
+  --color-icon-muted: #475569;   /* sidebar nav icons — inactive state */
+
+  /* --- Status --- */
+  --color-danger:  #ef4444;
+  --color-success: #05730c;
+}


### PR DESCRIPTION
## implementation
- Add src/styles/theme.css as the single source of truth for all colours.
- Replace every hardcoded hex/rgba value across SCSS files and JSX inline props with var(--color-*) tokens. Changing a palette now requires editing only theme.css.

## Issue
#130 