### PR TITLE
fix(popups): add proper backdrop effect when popup is open

### DIFF
--- a/src/components/ArtGallery/index.js
+++ b/src/components/ArtGallery/index.js
@@ -156,6 +156,7 @@ const handleTouchEnd = (e) => {
           <img src={art[showKey]?.image} alt={"art"} className="art-lightbox-img" />
         </div>
       )}
+      {showPopup && <div className="popup-backdrop" onClick={closePopup} />}
       <div
         className={showPopup ? "art-popup" : "popup-disabled"}
         ref={popupRef}

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -256,9 +256,6 @@
   }
 }
 
-.blur-background {
-  backdrop-filter: blur(2px);
-}
 
 .art-name {
   display: none;

--- a/src/components/PaperShelf/index.js
+++ b/src/components/PaperShelf/index.js
@@ -301,6 +301,7 @@ const PaperShelf = () => {
 
   return (
     <>
+      {showPopup && <div className="popup-backdrop" onClick={closeSummaryPopup} />}
       <div className={showPopup ? "summary-popup" : "popup-disabled"} ref={popupRef}>
         <FontAwesomeIcon
           onClick={closeSummaryPopup}

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -323,9 +323,6 @@
   }
 }
 
-.blur-background {
-  backdrop-filter: blur(2px);
-}
 
 .summary-title {
   color: var(--color-text-primary);

--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -117,6 +117,7 @@ const Skills = () => {
 
   return (
     <>
+      {showPopup && <div className="popup-backdrop" onClick={closePopup} />}
       <div className={showPopup ? "popup" : "popup-disabled"} ref={popupRef}>
         <div>
           <FontAwesomeIcon

--- a/src/components/Skills/index.scss
+++ b/src/components/Skills/index.scss
@@ -164,9 +164,6 @@
   }
 }
 
-.blur-background {
-  backdrop-filter: blur(2px);
-}
 
 .skills-section {
   position: relative;

--- a/src/index.css
+++ b/src/index.css
@@ -16,3 +16,19 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+.popup-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  z-index: 998;
+}
+
+.blur-background {
+  filter: blur(4px);
+  pointer-events: none;
+  user-select: none;
+  transition: filter 0.2s ease;
+}


### PR DESCRIPTION
## Implementation
Replace the no-op backdrop-filter on the content div with a fixed .popup-backdrop overlay (dark tint + blur) at z-index 998, and fix .blur-background to use filter: blur() so the page content behind the popup is actually blurred. Both classes are now global in index.css.

## Issue
#127 