### PR TITLE
feat: modernize typography and add visual depth across all pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,9 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -7,11 +7,11 @@
   overflow: auto;
 
   h1 {
-    color: var(--color-accent);
+    color: var(--color-text-primary);
     font-size: 53px;
     margin: 0;
-    font-family: "Coolvetica", sans-serif;
-    font-weight: 400;
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
     text-align: left;
     margin-bottom: 40px;
   }

--- a/src/components/Career/index.scss
+++ b/src/components/Career/index.scss
@@ -7,11 +7,11 @@
   overflow: auto;
 
   h1 {
-    color: var(--color-accent);
+    color: var(--color-text-primary);
     font-size: 53px;
     margin: 0;
-    font-family: "Coolvetica", sans-serif;
-    font-weight: 400;
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
     text-align: left;
     margin-bottom: 40px;
   }

--- a/src/components/Home/index.scss
+++ b/src/components/Home/index.scss
@@ -1,4 +1,32 @@
 .home-page {
+  overflow: hidden;
+
+  /* Amber orb — top right */
+  &::before {
+    content: '';
+    position: absolute;
+    width: 800px;
+    height: 800px;
+    background: radial-gradient(circle, rgba(var(--color-accent-rgb), 0.07) 0%, transparent 65%);
+    top: -250px;
+    right: -200px;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  /* Teal orb — bottom left */
+  &::after {
+    content: '';
+    position: absolute;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle, rgba(6, 182, 212, 0.05) 0%, transparent 65%);
+    bottom: -150px;
+    left: -100px;
+    pointer-events: none;
+    z-index: 0;
+  }
+
   .text-zone {
     position: absolute;
     left: 10%;
@@ -7,6 +35,7 @@
     width: 40%;
     max-height: 90%;
     text-align: left;
+    z-index: 1;
 
     .about-text-zone {
       p {
@@ -43,8 +72,8 @@
     color: #fff;
     font-size: 53px;
     margin: 0;
-    font-family: "Coolvetica", sans-serif;
-    font-weight: 400;
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
 
     img {
       width: 62px;

--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -32,9 +32,9 @@
 
     h1 {
       font-size: 53px;
-      font-family: "Coolvetica", "sans-serif";
-      color: var(--color-accent);
-      font-weight: 400;
+      font-family: "Space Grotesk", sans-serif;
+      color: var(--color-text-primary);
+      font-weight: 700;
       margin-top: 0;
       position: relative;
       margin-bottom: 40px;

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -7,11 +7,11 @@
   overflow: auto;
 
   h1 {
-    color: var(--color-accent);
+    color: var(--color-text-primary);
     font-size: 53px;
     margin: 0;
-    font-family: "Coolvetica", sans-serif;
-    font-weight: 400;
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
     text-align: left;
     margin-bottom: 40px;
   }

--- a/src/components/Skills/index.scss
+++ b/src/components/Skills/index.scss
@@ -7,11 +7,11 @@
   overflow: auto;
 
   h1 {
-    color: var(--color-accent);
+    color: var(--color-text-primary);
     font-size: 53px;
     margin: 0;
-    font-family: "Coolvetica", sans-serif;
-    font-weight: 400;
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
     text-align: left;
     margin-bottom: 40px;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,17 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Subtle dot grid texture — sits behind everything */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
 .popup-backdrop {
   position: fixed;
   inset: 0;
@@ -32,4 +43,26 @@ body {
   pointer-events: none;
   user-select: none;
   transition: filter 0.2s ease;
+}
+
+/* Section heading accent bar — all pages except home hero */
+h1.page-title::before,
+.container.about-page .text-zone h1::before,
+.container.contact-page .text-zone h1::before {
+  content: '';
+  display: block;
+  width: 48px;
+  height: 4px;
+  background: var(--color-accent);
+  border-radius: 2px;
+  margin-bottom: 14px;
+}
+
+/* Amber glow on section headings */
+h1.page-title,
+.container.about-page .text-zone h1,
+.container.contact-page .text-zone h1 {
+  text-shadow:
+    0 0 30px rgba(var(--color-accent-rgb), 0.45),
+    0 0 80px rgba(var(--color-accent-rgb), 0.2);
 }


### PR DESCRIPTION
## Implementation
  - Replace Coolvetica with Space Grotesk (700) for all headings — modern geometric font suited to a technical portfolio
  - Change section heading color from amber to white; reserve amber for the accent bar above each heading
  - Add amber accent bar (::before) to all section headings site-wide
  - Add subtle dot grid background texture (body::before) for depth
  - Add ambient gradient orbs to hero (amber top-right, teal bottom-left)
  - Add layered amber text-shadow glow to section headings

## Issue
#148