### PR TITLE
feat(Home): modernize hero subtitle, bio, stats, and button

### DIFF
--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -61,32 +61,35 @@ const Home = () => {
             idx={20}
           />
         </h1>
-        <h2>Backend Engineer / Tech Blogger / Artist</h2>
+        <div className="role-chips">
+          <span className="role-chip">Backend Engineer</span>
+          <span className="role-chip">Tech Blogger</span>
+          <span className="role-chip">Artist</span>
+        </div>
         <div className={"about-text-zone"}>
           <p>
-            I'm a skilled{" "}
-            <span className={"standout-text"}>Software Engineer</span> with a
-            strong interest in cutting-edge technologies such as Blockchain,
-            Hybrid-Multi Cloud, Machine Learning, DevOps, Cloud Computing, and
-            Security. Currently, I work as a Senior Backend Engineer at MaxIQ.
+            Senior <span className={"standout-text"}>Backend Engineer</span> at
+            MaxIQ, working across Backend, Cloud, ML, DevOps, and Security. I
+            contribute to open-source and write technical articles on Medium.
           </p>
-          <p>
-            As a tech enthusiast, I take pleasure in learning and incorporating
-            new technologies into my work.
-            <br />I have programmed for <span className={"standout-text"}>
-              {currentYear - firstProgrammedYear}
-            </span>{" "}
-            years, <span className={"standout-text"}>
-              {currentYear - firstProfessionalProgrammingYear}
-            </span> professionally.
-          </p>
-          <p>
-            Apart from my work, I actively contribute to open-source projects and
-            write technical articles on Medium.
-          </p>
+          <div className="hero-stats">
+            <div className="hero-stat">
+              <span className="hero-stat-number">
+                {currentYear - firstProgrammedYear}
+              </span>
+              <span className="hero-stat-label">years coding</span>
+            </div>
+            <div className="hero-stat-divider" />
+            <div className="hero-stat">
+              <span className="hero-stat-number">
+                {currentYear - firstProfessionalProgrammingYear}
+              </span>
+              <span className="hero-stat-label">years professional</span>
+            </div>
+          </div>
         </div>
         <Link to={"/contact"} className={"flat-button"}>
-          CONTACT ME
+          Contact Me
         </Link>
       </div>
       <Logo />

--- a/src/components/Home/index.scss
+++ b/src/components/Home/index.scss
@@ -61,8 +61,7 @@
       }
 
       .standout-text {
-        font-size: 20px;
-        font-weight: 400;
+        font-weight: 600;
         color: var(--color-accent);
       }
     }
@@ -70,14 +69,14 @@
 
   h1 {
     color: #fff;
-    font-size: 53px;
+    font-size: clamp(28px, 7.5vw, 53px);
     margin: 0;
     font-family: "Space Grotesk", sans-serif;
     font-weight: 700;
 
     img {
-      width: 62px;
-      margin-left: 20px;
+      width: 1.17em;
+      margin-left: 0.38em;
       opacity: 0;
       height: auto;
       animation: rotateIn 1s linear both;
@@ -86,34 +85,87 @@
   }
 }
 
-h2 {
-  color: var(--color-text-subtle);
-  margin-top: 20px;
-  font-weight: 40;
-  font-size: 12px;
-  font-family: sans-serif;
-  letter-spacing: 3px;
+/* Role chips */
+.role-chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 16px 0 24px;
   animation: fadeIn 1s 1.8s backwards;
+}
+
+.role-chip {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 5px 13px;
+  font-family: "Space Grotesk", sans-serif;
+  letter-spacing: 0.01em;
+}
+
+/* Stat row */
+.hero-stats {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin: 20px 0 4px;
+  animation: fadeIn 1s 2s backwards;
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hero-stat-number {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-accent);
+  font-family: "Space Grotesk", sans-serif;
+  line-height: 1;
+}
+
+.hero-stat-label {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  font-family: sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.hero-stat-divider {
+  width: 1px;
+  height: 36px;
+  background: var(--color-border);
 }
 
 .home-page {
   .flat-button {
-    color: var(--color-accent);
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    background: var(--color-accent);
+    color: var(--color-bg);
     font-size: 13px;
-    font-weight: 400;
-    letter-spacing: 4px;
-    font-family: sans-serif;
+    font-weight: 600;
+    font-family: "Space Grotesk", sans-serif;
+    letter-spacing: 0.02em;
     text-decoration: none;
-    padding: 10px 18px;
-    border: 1px solid var(--color-accent);
-    margin-top: 25px;
-    float: left;
-    animation: fadeIn 1s 1.8s backwards;
+    padding: 11px 24px;
+    border: none;
+    border-radius: 6px;
+    margin-top: 28px;
+    animation: fadeIn 1s 2.2s backwards;
     white-space: nowrap;
+    transition: filter 0.2s ease, transform 0.2s ease;
 
     &:hover {
-      background: var(--color-accent);
-      color: var(--color-bg);
+      filter: brightness(1.1);
+      transform: translateY(-1px);
     }
   }
 }
@@ -129,10 +181,8 @@ h2 {
     }
 
     .flat-button {
-      float: none;
-      display: block;
+      display: inline-flex;
       margin: 20px auto 0 auto;
-      width: 125px;
     }
 
     .logo-container {


### PR DESCRIPTION
## Implementation
  - Replace spaced-caps h2 subtitle with role chip pills (Backend Engineer / Tech Blogger / Artist)
  - Condense 3-paragraph bio into one tight sentence
  - Replace inline highlighted stats with a clean stat row (large number + label, with divider) — Linear-inspired
  - Modernize CTA button: solid amber fill, sentence case, subtle hover lift; fix full-width stretch with fit-content
  - Use clamp(28px, 7.5vw, 53px) on h1 to prevent mid-word breaks on small screens
  - Scale logo image with em units so it shrinks with the font

## Issue
#149 