### PR TITLE
feat(ArtGallery): deduplicate landscape titles and add medium filtering

### DIFF
--- a/src/components/ArtGallery/index.js
+++ b/src/components/ArtGallery/index.js
@@ -6,9 +6,12 @@ import { faClose, faChevronLeft, faChevronRight } from "@fortawesome/free-solid-
 import useScrollLock from "../../hooks/useScrollLock";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
+const MEDIUMS = ["All", ...Array.from(new Set(artCategories.map((a) => a.description)))];
+
 const ArtGallery = () => {
   const [letterClass, setLetterClass] = useState("text-animate");
   const [art, setArt] = useState([]);
+  const [activeFilter, setActiveFilter] = useState("All");
   const [showPopup, setShowPopup] = useState(false);
   const [showFullImage, setShowFullImage] = useState(false);
   const [showKey, setShowKey] = useState(0);
@@ -124,16 +127,21 @@ const handleTouchEnd = (e) => {
     setArt(artCategories.map((doc) => doc));
   };
 
+  const filteredArt = activeFilter === "All"
+    ? art
+    : art.filter((a) => a.description === activeFilter);
+
   const renderArt = (arts) => {
     return (
       <div className="images-container">
         {arts.map((port, idx) => {
+          const globalIdx = art.indexOf(port);
           return (
             <div
               className="image-box"
               key={idx}
               onClick={() => {
-                setShowKey(idx);
+                setShowKey(globalIdx);
                 setShowPopup(true);
               }}
             >
@@ -202,7 +210,18 @@ const handleTouchEnd = (e) => {
               idx={15}
             />
           </h1>
-          <div>{renderArt(art)}</div>
+          <div className="filter-bar">
+            {MEDIUMS.map((medium) => (
+              <button
+                key={medium}
+                className={`filter-btn${activeFilter === medium ? " filter-btn--active" : ""}`}
+                onClick={() => setActiveFilter(medium)}
+              >
+                {medium}
+              </button>
+            ))}
+          </div>
+          <div>{renderArt(filteredArt)}</div>
         </div>
       </div>
     </>

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -21,6 +21,38 @@
     margin-top: 100px;
   }
 
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 28px;
+    margin-left: 100px;
+  }
+
+  .filter-btn {
+    padding: 6px 16px;
+    border-radius: 20px;
+    border: 1px solid var(--color-border);
+    background: linear-gradient(to bottom right, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
+    color: var(--color-text-subtle);
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    backdrop-filter: blur(1rem) saturate(160%);
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
+    }
+
+    &--active {
+      background: linear-gradient(135deg, rgba(var(--color-accent-rgb), 0.3), rgba(var(--color-accent-rgb), 0.1));
+      border-color: var(--color-accent);
+      color: var(--color-accent);
+    }
+  }
+
   .images-container {
     display: flex;
     gap: 15px;
@@ -315,6 +347,10 @@
 }
 
 @media screen and (max-width: 1200px) {
+  .art-gallery-page .filter-bar {
+    margin-left: 0;
+  }
+
   .image-box {
     flex: 1 1 30% !important;
   }

--- a/src/data/arts.js
+++ b/src/data/arts.js
@@ -14,14 +14,14 @@ let artCategories = [
     creationDate: "July 10, 2022",
   },
   {
-    name: "Landscape Painting",
+    name: "Landscape · Sept 2023",
     description: "Acrylic Painting",
     image:
       "https://drive.google.com/thumbnail?id=1sXrwe09hRJSymww4QL_1WBXhXdeiYfvg&sz=w900-h900",
     creationDate: "Sept 22, 2023",
   },
   {
-    name: "Landscape Painting",
+    name: "Landscape · Nov 2024",
     description: "Acrylic Painting",
     image:
       "https://drive.google.com/thumbnail?id=1sLJhUHrac1jPvLgCqNVS3-bBPXUhXr6W&sz=w900-h900",
@@ -35,14 +35,14 @@ let artCategories = [
     creationDate: "Dec 31, 2022",
   },
   {
-    name: "Landscape Painting",
+    name: "Landscape · Apr 2024",
     description: "Acrylic Painting",
     image:
       "https://drive.google.com/thumbnail?id=1mqVoWHW5kKqhKVbsyX_KmKi-gBG9fvKg&sz=w900-h900",
     creationDate: "Apr 14, 2024",
   },
   {
-    name: "Landscape Painting",
+    name: "Landscape · Apr 2023",
     description: "Acrylic Painting",
     image:
       "https://drive.google.com/thumbnail?id=1Y4hRdxwSqRpUlB29NhMgJD_3JuWRTZOE&sz=w900-h900",
@@ -63,7 +63,7 @@ let artCategories = [
     creationDate: "Mar 06, 2022",
   },
   {
-    name: "Landscape Painting",
+    name: "Landscape · Dec 2021",
     description: "Water Color Painting",
     image:
       "https://drive.google.com/thumbnail?id=1XgaWU1hgiZai8lvQ99avyM4zS_WcfBGf&sz=w900-h900",


### PR DESCRIPTION
## Implementation
Rename 5 generic "Landscape Painting" entries with month/year suffix so every card title is unique. Add a filter bar above the grid with glassmorphism pill buttons (All + one per medium) so visitors can narrow the collection by medium. Popup navigation continues to use the full unfiltered index so keyboard/swipe traversal is unaffected.

## Issue
#152 