### PR TITLE
fix(layout): unify section left margin with Home and fix content alignment

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,17 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap" rel="stylesheet" />
     <title>Ankush Chavan | Software Engineer | Backend Developer</title>
+    <!-- Single Page Apps for GitHub Pages — restores path after 404.html redirect -->
+    <script type="text/javascript">
+      (function(l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&');
+          }).join('?');
+          window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+        }
+      }(window.location));
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,27 +6,27 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://ankushchavan.com/#/skills</loc>
+    <loc>https://ankushchavan.com/skills</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://ankushchavan.com/#/career</loc>
+    <loc>https://ankushchavan.com/career</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://ankushchavan.com/#/paper-shelf</loc>
+    <loc>https://ankushchavan.com/paper-shelf</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://ankushchavan.com/#/art-gallery</loc>
+    <loc>https://ankushchavan.com/art-gallery</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://ankushchavan.com/#/contact</loc>
+    <loc>https://ankushchavan.com/contact</loc>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/src/components/ArtGallery/index.js
+++ b/src/components/ArtGallery/index.js
@@ -146,7 +146,7 @@ const handleTouchEnd = (e) => {
                 setShowPopup(true);
               }}
             >
-              <img src={port.image} className="art-image" alt={port.name} />
+              <img src={port.image} className="art-image" alt={port.name} loading="lazy" />
               <div className="image-date">
                 <p>{port.creationDate}</p>
               </div>
@@ -168,7 +168,7 @@ const handleTouchEnd = (e) => {
         <meta name="description" content="Original artwork by Ankush Chavan — pencil sketches, digital illustrations, and mixed media pieces blending art with a software engineer's perspective." />
         <meta property="og:title" content="Art Gallery | Ankush Chavan" />
         <meta property="og:description" content="Original artwork by Ankush Chavan — pencil sketches, digital illustrations, and mixed media pieces blending art with a software engineer's perspective." />
-        <meta property="og:url" content="https://ankushchavan.com/#/art-gallery" />
+        <meta property="og:url" content="https://ankushchavan.com/art-gallery" />
       </Helmet>
       {showFullImage && (
         <div className="art-lightbox" ref={lightboxRef} onClick={() => setShowFullImage(false)}>

--- a/src/components/ArtGallery/index.scss
+++ b/src/components/ArtGallery/index.scss
@@ -1,7 +1,8 @@
 .art-gallery-page {
-  padding-left: 100px;
+  padding-left: 10%;
   padding-right: 50px;
-  width: calc(100% - 150px);
+  width: 100%;
+  box-sizing: border-box;
   position: initial;
   height: 100%;
   overflow: auto;
@@ -17,7 +18,6 @@
   }
 
   h1.page-title {
-    margin-left: 100px;
     margin-top: 100px;
   }
 
@@ -26,7 +26,6 @@
     flex-wrap: wrap;
     gap: 10px;
     margin-bottom: 28px;
-    margin-left: 100px;
   }
 
   .filter-btn {
@@ -347,10 +346,6 @@
 }
 
 @media screen and (max-width: 1200px) {
-  .art-gallery-page .filter-bar {
-    margin-left: 0;
-  }
-
   .image-box {
     flex: 1 1 30% !important;
   }

--- a/src/components/Career/index.js
+++ b/src/components/Career/index.js
@@ -58,7 +58,7 @@ const Career = () => {
       <meta name="description" content="Ankush Chavan's professional career timeline — software engineering roles at MaxIQ, Velotio Technologies, Phoenixgen Systems, and academic background." />
       <meta property="og:title" content="Career | Ankush Chavan" />
       <meta property="og:description" content="Ankush Chavan's professional career timeline — software engineering roles at MaxIQ, Velotio Technologies, Phoenixgen Systems, and academic background." />
-      <meta property="og:url" content="https://ankushchavan.com/#/career" />
+      <meta property="og:url" content="https://ankushchavan.com/career" />
     </Helmet>
     <div className={"container career-page"}>
       <h1 className={"page-title"}>

--- a/src/components/Career/index.scss
+++ b/src/components/Career/index.scss
@@ -1,7 +1,8 @@
 .career-page {
-  padding-left: 100px;
+  padding-left: 10%;
   padding-right: 50px;
-  width: calc(100% - 150px);
+  width: 100%;
+  box-sizing: border-box;
   position: initial;
   height: 100%;
   overflow: auto;
@@ -17,7 +18,6 @@
   }
 
   h1.page-title {
-    margin-left: 100px;
     margin-top: 100px;
   }
 

--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -89,7 +89,7 @@ const Contact = () => {
       <meta name="description" content="Get in touch with Ankush Chavan — open to collaborations, engineering discussions, and opportunities in backend and distributed systems." />
       <meta property="og:title" content="Contact | Ankush Chavan" />
       <meta property="og:description" content="Get in touch with Ankush Chavan — open to collaborations, engineering discussions, and opportunities in backend and distributed systems." />
-      <meta property="og:url" content="https://ankushchavan.com/#/contact" />
+      <meta property="og:url" content="https://ankushchavan.com/contact" />
     </Helmet>
     <div>
       <div className={"container contact-page"}>

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -95,7 +95,7 @@ const Layout = () => {
   return (
     <div className={"App"}>
       <Sidebar />
-      <div className={"page"}>
+      <main className={"page"}>
         <section id="home" className="scroll-section">
           <Home />
         </section>
@@ -114,7 +114,7 @@ const Layout = () => {
         <section id="contact" className="scroll-section">
           <Contact />
         </section>
-      </div>
+      </main>
     </div>
   );
 };

--- a/src/components/Layout/index.scss
+++ b/src/components/Layout/index.scss
@@ -36,9 +36,7 @@
       color: var(--color-text-primary);
       font-weight: 700;
       margin-top: 0;
-      position: relative;
       margin-bottom: 40px;
-      left: 10px;
     }
 
     p {
@@ -106,7 +104,6 @@
       box-sizing: border-box;
 
       h1.page-title {
-        margin-left: 20px;
         margin-top: 20px;
       }
 

--- a/src/components/PaperShelf/index.js
+++ b/src/components/PaperShelf/index.js
@@ -165,7 +165,7 @@ const PaperShelf = () => {
         {books[showBookKey]?.map((port, idx) => {
           return (
             <div className="image-box" key={idx}>
-              <img src={port.image} className="entity-image" alt={port.name} />
+              <img src={port.image} className="entity-image" alt={port.name} loading="lazy" />
               <div className="read-date">
                 <p>{port.readDate ?? port.writtenDate}</p>
               </div>
@@ -231,6 +231,7 @@ const PaperShelf = () => {
                 src={port.image}
                 className="entity-image"
                 alt={port.name}
+                loading="lazy"
               />
               <div className="read-date">
                 <p>{port.readDate ?? port.writtenDate}</p>
@@ -270,7 +271,7 @@ const PaperShelf = () => {
         {blogs[showBlogKey]?.map((port, idx) => {
           return (
             <div className="image-box" key={idx}>
-              <img src={port.image} className="entity-image" alt={port.name} />
+              <img src={port.image} className="entity-image" alt={port.name} loading="lazy" />
               <div className="read-date">
                 <p>{port.readDate ?? port.writtenDate}</p>
               </div>
@@ -310,7 +311,7 @@ const PaperShelf = () => {
         <meta name="description" content="Books, research papers, and tech blogs curated by Ankush Chavan — covering distributed systems, backend engineering, and software architecture." />
         <meta property="og:title" content="Paper Shelf | Ankush Chavan" />
         <meta property="og:description" content="Books, research papers, and tech blogs curated by Ankush Chavan — covering distributed systems, backend engineering, and software architecture." />
-        <meta property="og:url" content="https://ankushchavan.com/#/paper-shelf" />
+        <meta property="og:url" content="https://ankushchavan.com/paper-shelf" />
       </Helmet>
       {showPopup && <div className="popup-backdrop" onClick={closeSummaryPopup} />}
       <div className={showPopup ? "summary-popup" : "popup-disabled"} ref={popupRef}>

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -1,7 +1,8 @@
 .paper-shelf-page {
-  padding-left: 100px;
+  padding-left: 10%;
   padding-right: 50px;
-  width: calc(100% - 150px);
+  width: 100%;
+  box-sizing: border-box;
   position: initial;
   height: 100%;
   overflow: auto;
@@ -17,7 +18,6 @@
   }
 
   h1.page-title {
-    margin-left: 100px;
     margin-top: 100px;
   }
 
@@ -84,6 +84,7 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
+    top: 0;
     left: 0;
   }
 

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -40,7 +40,7 @@ const Sidebar = () => {
   };
 
   return (
-    <div className="nav-bar">
+    <header className="nav-bar">
       <a className="logo" href="#home" onClick={(e) => handleNavClick(e, "home", "/")}>
         <img src={Logo} alt="logo" />
         {/*<img className="sub-logo" src={LogoSubtitle} alt="logo-subtitle"/>*/}
@@ -159,7 +159,7 @@ const Sidebar = () => {
         size={"3x"}
         className={"hamburger-icon"}
       />
-    </div>
+    </header>
   );
 };
 

--- a/src/components/Skills/index.js
+++ b/src/components/Skills/index.js
@@ -170,7 +170,7 @@ const Skills = () => {
         <meta name="description" content="Explore Ankush Chavan's technical skills spanning backend development, distributed systems, cloud infrastructure, databases, and more." />
         <meta property="og:title" content="Skills | Ankush Chavan" />
         <meta property="og:description" content="Explore Ankush Chavan's technical skills spanning backend development, distributed systems, cloud infrastructure, databases, and more." />
-        <meta property="og:url" content="https://ankushchavan.com/#/skills" />
+        <meta property="og:url" content="https://ankushchavan.com/skills" />
       </Helmet>
       {showPopup && <div className="popup-backdrop" onClick={closePopup} />}
       <div className={showPopup ? "popup" : "popup-disabled"} ref={popupRef}>

--- a/src/components/Skills/index.scss
+++ b/src/components/Skills/index.scss
@@ -1,7 +1,8 @@
 .skills-page {
-  padding-left: 100px;
+  padding-left: 10%;
   padding-right: 50px;
-  width: calc(100% - 150px);
+  width: 100%;
+  box-sizing: border-box;
   position: initial;
   height: 100%;
   overflow: auto;
@@ -17,7 +18,6 @@
   }
 
   h1.page-title {
-    margin-left: 100px;
     margin-top: 100px;
   }
 
@@ -29,7 +29,6 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   padding-bottom: 100px;
-  margin-left: 100px;
 }
 
 .skill-card {

--- a/src/index.js
+++ b/src/index.js
@@ -3,16 +3,16 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <HelmetProvider>
-      <HashRouter>
+      <BrowserRouter>
         <App />
-      </HashRouter>
+      </BrowserRouter>
     </HelmetProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Implementation
  - Switch HashRouter → BrowserRouter with spa-github-pages decode script
  - Replace fixed 200px double-indent (padding + margin) with padding-left: 10% across Skills, Career, PaperShelf, ArtGallery — matching Home's left: 10%
  - Remove .text-zone h1 left: 10px offset that misaligned title from content below
  - Align section content (cards grid, timeline, accordion, art grid) with their titles
  - Add loading="lazy" to PaperShelf and ArtGallery grid thumbnails
  - Fix entity-image overflow in PaperShelf cards with top: 0
  - Add <header> and <main> semantic landmarks to Sidebar and Layout

## Issue
#161 