### PR TITLE
feat(PaperShelf): migrate MUI Accordion to ShadCN

### DIFF
--- a/src/components/PaperShelf/index.jsx
+++ b/src/components/PaperShelf/index.jsx
@@ -4,12 +4,8 @@ import React, { useEffect, useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import usePopupClose from "../../hooks/usePopupClose";
 import useScrollLock from "../../hooks/useScrollLock";
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "../ui/accordion";
 import LinearProgress from "@mui/material/LinearProgress";
-import Box from "@mui/material/Box";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import books from "../../data/books";
 import papers from "../../data/papers";
 import blogs from "../../data/blogs";
@@ -113,7 +109,7 @@ const PaperShelf = () => {
                 <h4 className="authors">Authors: {port.authors}</h4>
 
                 {sectionKey === "books" && (
-                  <Box sx={{ width: "100%", display: "flex", alignItems: "center", gap: "6px", height: "16px" }}>
+                  <div style={{ width: "100%", display: "flex", alignItems: "center", gap: "6px", height: "16px" }}>
                     <LinearProgress
                       variant="determinate"
                       value={(port.pagesRead / port.totalPages) * 100}
@@ -137,7 +133,7 @@ const PaperShelf = () => {
                         <path d="M4.5 8l2.5 2.5 4.5-4.5" stroke="#05730c" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                       </svg>
                     )}
-                  </Box>
+                  </div>
                 )}
 
                 <div className="button-container">
@@ -207,32 +203,27 @@ const PaperShelf = () => {
               idx={15}
             />
           </h1>
-          <div className="content-zone">
-            {SECTIONS.map(({ key, label, data, defaultExpanded }) => (
-              <Accordion
-                key={key}
-                defaultExpanded={defaultExpanded}
-                disableGutters
-                square={key !== "blogs"}
-                className="content-sections"
-                sx={{ backgroundImage: "none" }}
-              >
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon className="expand-icon" />}
+          <Accordion
+            defaultValue={SECTIONS.filter(s => s.defaultExpanded).map(s => s.key)}
+            className="content-zone"
+          >
+            {SECTIONS.map(({ key, label, data }) => (
+              <AccordionItem key={key} value={key} className="content-sections">
+                <AccordionTrigger
                   aria-controls={`${key}-content`}
                   className={`${key}-header`}
                 >
                   <h3>{label}</h3>
-                </AccordionSummary>
-                <AccordionDetails className="content-details">
+                </AccordionTrigger>
+                <AccordionContent className="content-details">
                   <div>
                     {renderReadWrittenToggle(key)}
                     {renderItems(key, data, activeKeys[key])}
                   </div>
-                </AccordionDetails>
-              </Accordion>
+                </AccordionContent>
+              </AccordionItem>
             ))}
-          </div>
+          </Accordion>
         </div>
       </div>
     </>

--- a/src/components/PaperShelf/index.scss
+++ b/src/components/PaperShelf/index.scss
@@ -31,14 +31,39 @@
   .content-sections {
     background-color: var(--color-bg-surface);
     transition: background-color 0.2s;
+    // Remove the bottom border ShadCN AccordionItem adds between sections
+    border: none;
 
     h3 {
       color: var(--color-text-secondary);
       margin: 0;
+      font-size: 14px;
+      font-weight: 600;
     }
 
-    .expand-icon {
+    // Target ShadCN accordion trigger icon (replaces MUI ExpandMoreIcon)
+    [data-slot="accordion-trigger-icon"] {
       color: var(--color-text-muted);
+    }
+
+    // ShadCN trigger is a <button> — reset browser default button appearance
+    // and disable the hover:underline that ShadCN applies by default
+    [data-slot="accordion-trigger"] {
+      appearance: none;
+      background: transparent;
+      border: none;
+      border-radius: 0;
+      width: 100%;
+      padding: 13px 16px;
+      cursor: pointer;
+      text-decoration: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
 
     &:hover {
@@ -48,7 +73,7 @@
         color: var(--color-text-primary);
       }
 
-      .expand-icon {
+      [data-slot="accordion-trigger-icon"] {
         color: var(--color-text-primary);
       }
     }

--- a/src/components/ui/accordion.jsx
+++ b/src/components/ui/accordion.jsx
@@ -1,0 +1,77 @@
+import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+function Accordion({
+  className,
+  ...props
+}) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn("flex w-full flex-col", className)}
+      {...props} />
+  );
+}
+
+function AccordionItem({
+  className,
+  ...props
+}) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("not-last:border-b", className)}
+      {...props} />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "group/accordion-trigger relative flex flex-1 items-start justify-between rounded-lg border border-transparent py-2.5 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:after:border-ring aria-disabled:pointer-events-none aria-disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 **:data-[slot=accordion-trigger-icon]:text-muted-foreground",
+          className
+        )}
+        {...props}>
+        {children}
+        <ChevronDownIcon
+          data-slot="accordion-trigger-icon"
+          className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden" />
+        <ChevronUpIcon
+          data-slot="accordion-trigger-icon"
+          className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <AccordionPrimitive.Panel
+      data-slot="accordion-content"
+      className="overflow-hidden text-sm data-open:animate-accordion-down data-closed:animate-accordion-up"
+      {...props}>
+      <div
+        className={cn(
+          "h-(--accordion-panel-height) pt-0 pb-2.5 data-ending-style:h-0 data-starting-style:h-0 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+          className
+        )}>
+        {children}
+      </div>
+    </AccordionPrimitive.Panel>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }


### PR DESCRIPTION
## Implementation
  - Replace MUI Accordion/AccordionSummary/AccordionDetails with ShadCN Accordion/AccordionItem/AccordionTrigger/AccordionContent
  - Replace MUI Box with plain div for LinearProgress wrapper
  - Remove MUI ExpandMoreIcon (ShadCN trigger has built-in chevron)
  - Reset browser default button styles on accordion trigger
  - Fix accordion header font size, weight, and padding to match original

## Issue
#171 